### PR TITLE
feat: "Did you mean...?" spelling suggestions when no definitions found

### DIFF
--- a/Definition/Community.PowerToys.Run.Plugin.Definition.UnitTests/SuggestionProviderTests.cs
+++ b/Definition/Community.PowerToys.Run.Plugin.Definition.UnitTests/SuggestionProviderTests.cs
@@ -40,7 +40,7 @@ namespace Community.PowerToys.Run.Plugin.Definition.UnitTests
         public async Task ParsesWordsAndSkipsOriginal()
         {
             var provider = Make(HttpStatusCode.OK, "[{\"word\":\"run\"},{\"word\":\"serendipiti\"},{\"word\":\"run\"}]");
-            var result = await provider.GetSuggestionsAsync("serendipityy", CancellationToken.None);
+            var result = await provider.GetSuggestionsAsync("serendipityy", 5, CancellationToken.None);
 
             CollectionAssert.AreEqual(new[] { "run", "serendipiti" }, result.ToList());
         }
@@ -49,21 +49,30 @@ namespace Community.PowerToys.Run.Plugin.Definition.UnitTests
         public async Task EmptyOnHttpError()
         {
             var provider = Make(HttpStatusCode.NotFound, "[]");
-            Assert.AreEqual(0, (await provider.GetSuggestionsAsync("x", CancellationToken.None)).Count);
+            Assert.AreEqual(0, (await provider.GetSuggestionsAsync("x", 5, CancellationToken.None)).Count);
         }
 
         [TestMethod]
         public async Task EmptyOnGarbageJson()
         {
             var provider = Make(HttpStatusCode.OK, "<html>not json</html>");
-            Assert.AreEqual(0, (await provider.GetSuggestionsAsync("x", CancellationToken.None)).Count);
+            Assert.AreEqual(0, (await provider.GetSuggestionsAsync("x", 5, CancellationToken.None)).Count);
         }
 
         [TestMethod]
         public async Task EmptyOnTooLongWord()
         {
             var provider = Make(HttpStatusCode.OK, "[]");
-            Assert.AreEqual(0, (await provider.GetSuggestionsAsync(new string('a', 51), CancellationToken.None)).Count);
+            Assert.AreEqual(0, (await provider.GetSuggestionsAsync(new string('a', 51), 5, CancellationToken.None)).Count);
+        }
+
+        [TestMethod]
+        public async Task RespectsCustomMax()
+        {
+            var json = "[" + string.Join(",", Enumerable.Range(0, 12).Select(i => $"{{\"word\":\"w{i}\"}}")) + "]";
+            var provider = Make(HttpStatusCode.OK, json);
+            var result = await provider.GetSuggestionsAsync("qq", 10, CancellationToken.None);
+            Assert.AreEqual(10, result.Count);
         }
     }
 }

--- a/Definition/Community.PowerToys.Run.Plugin.Definition.UnitTests/SuggestionProviderTests.cs
+++ b/Definition/Community.PowerToys.Run.Plugin.Definition.UnitTests/SuggestionProviderTests.cs
@@ -1,0 +1,69 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Community.PowerToys.Run.Plugin.Definition;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+
+namespace Community.PowerToys.Run.Plugin.Definition.UnitTests
+{
+    [TestClass]
+    public class SuggestionProviderTests
+    {
+        private sealed class FakeHandler : HttpMessageHandler
+        {
+            private readonly HttpStatusCode _code;
+            private readonly string _json;
+
+            public FakeHandler(HttpStatusCode code, string json)
+            {
+                _code = code;
+                _json = json;
+            }
+
+            protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken token)
+            {
+                return Task.FromResult(new HttpResponseMessage(_code) { Content = new StringContent(_json, Encoding.UTF8, "application/json") });
+            }
+        }
+
+        private static SuggestionProvider Make(HttpStatusCode code, string json)
+        {
+            return new SuggestionProvider(new HttpClient(new FakeHandler(code, json)));
+        }
+
+        [TestMethod]
+        public async Task ParsesWordsAndSkipsOriginal()
+        {
+            var provider = Make(HttpStatusCode.OK, "[{\"word\":\"run\"},{\"word\":\"serendipiti\"},{\"word\":\"run\"}]");
+            var result = await provider.GetSuggestionsAsync("serendipityy", CancellationToken.None);
+
+            CollectionAssert.AreEqual(new[] { "run", "serendipiti" }, result.ToList());
+        }
+
+        [TestMethod]
+        public async Task EmptyOnHttpError()
+        {
+            var provider = Make(HttpStatusCode.NotFound, "[]");
+            Assert.AreEqual(0, (await provider.GetSuggestionsAsync("x", CancellationToken.None)).Count);
+        }
+
+        [TestMethod]
+        public async Task EmptyOnGarbageJson()
+        {
+            var provider = Make(HttpStatusCode.OK, "<html>not json</html>");
+            Assert.AreEqual(0, (await provider.GetSuggestionsAsync("x", CancellationToken.None)).Count);
+        }
+
+        [TestMethod]
+        public async Task EmptyOnTooLongWord()
+        {
+            var provider = Make(HttpStatusCode.OK, "[]");
+            Assert.AreEqual(0, (await provider.GetSuggestionsAsync(new string('a', 51), CancellationToken.None)).Count);
+        }
+    }
+}

--- a/Definition/Community.PowerToys.Run.Plugin.Definition/Configuration.cs
+++ b/Definition/Community.PowerToys.Run.Plugin.Definition/Configuration.cs
@@ -24,6 +24,7 @@ namespace Community.PowerToys.Run.Plugin.Definition
         public string LatinLanguages { get; set; } = "en,fr,it";
         public string UkrainianApiEndpoint { get; set; } = "https://sum.in.ua/s/";
         public string ChineseApiEndpoint { get; set; } = "https://www.mdbg.net/chinese/dictionary?page=worddict&wdrst=0&wdqb=";
+        public int MaxSuggestions { get; set; } = 10;
     }
 
     internal static class ConfigurationManager

--- a/Definition/Community.PowerToys.Run.Plugin.Definition/Main.cs
+++ b/Definition/Community.PowerToys.Run.Plugin.Definition/Main.cs
@@ -62,6 +62,7 @@ namespace Community.PowerToys.Run.Plugin.Definition
         private readonly AudioManager _audioManager;
         private CancellationTokenSource _cancellationTokenSource;
         private readonly Dictionary<string, IDictionaryProvider> _dictionaryProviders;
+        private readonly SuggestionProvider _suggestionProvider;
         #endregion
 
         #region Initialization
@@ -77,6 +78,7 @@ namespace Community.PowerToys.Run.Plugin.Definition
                 { "uk", new UkrainianDictionaryProvider(HttpClient) },
                 { "zh", new ChineseDictionaryProvider(HttpClient) }
             };
+            _suggestionProvider = new SuggestionProvider(HttpClient);
         }
 
         public void Init(PluginInitContext context)
@@ -253,6 +255,40 @@ namespace Community.PowerToys.Run.Plugin.Definition
             return providers.Count > 0 ? providers : _dictionaryProviders.Values.Where(p => p.LanguageCode == "en");
         }
 
+
+        private async Task<List<Result>> BuildNotFoundResultsAsync(string searchTerm, string rawSearch, CancellationToken token)
+        {
+            var results = new List<Result> { CreateInfoResult(rawSearch, $"No definitions found for '{searchTerm}'", "Check spelling or try another word.") };
+            try
+            {
+                var suggestions = await _suggestionProvider.GetSuggestionsAsync(searchTerm, token);
+                foreach (var s in suggestions)
+                {
+                    results.Add(new Result
+                    {
+                        QueryTextDisplay = rawSearch,
+                        IcoPath = _iconManager.InfoIcon,
+                        Title = $"Did you mean: {s}?",
+                        SubTitle = "Search this spelling",
+                        ToolTipData = new ToolTipData($"Did you mean: {s}?", "Search this spelling"),
+                        Action = _ =>
+                        {
+                            // Re-run the query with the suggested spelling
+                            _context?.API?.ChangeQuery($"{_context.CurrentPluginMetadata.ActionKeyword} {s}", true);
+                            return false;
+                        },
+                        Score = 50
+                    });
+                }
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[Definition Plugin] Suggestions failed for '{searchTerm}': {ex.Message}");
+            }
+
+            return results;
+        }
+
         private enum ScriptType { Latin, Cyrillic, Cjk, Mixed }
 
         private async Task<List<Result>> FetchAndProcessResultsAsync(string searchTerm, string rawSearch, string subcommand, CancellationToken cancellationToken)
@@ -282,7 +318,7 @@ namespace Community.PowerToys.Run.Plugin.Definition
 
                 if (!allEntries.Any())
                 {
-                    return new List<Result> { CreateInfoResult(rawSearch, $"No definitions found for '{searchTerm}'", "Check spelling or try another word.") };
+                    return await BuildNotFoundResultsAsync(searchTerm, rawSearch, cancellationToken);
                 }
 
                 var results = ProcessDictionaryEntries(allEntries, rawSearch, subcommand);

--- a/Definition/Community.PowerToys.Run.Plugin.Definition/Main.cs
+++ b/Definition/Community.PowerToys.Run.Plugin.Definition/Main.cs
@@ -261,7 +261,7 @@ namespace Community.PowerToys.Run.Plugin.Definition
             var results = new List<Result> { CreateInfoResult(rawSearch, $"No definitions found for '{searchTerm}'", "Check spelling or try another word.") };
             try
             {
-                var suggestions = await _suggestionProvider.GetSuggestionsAsync(searchTerm, token);
+                var suggestions = await _suggestionProvider.GetSuggestionsAsync(searchTerm, ConfigurationManager.Configuration.MaxSuggestions, token);
                 foreach (var s in suggestions)
                 {
                     results.Add(new Result
@@ -510,6 +510,14 @@ namespace Community.PowerToys.Run.Plugin.Definition
                     },
                     new PluginAdditionalOption
                     {
+                        Key = nameof(PluginConfiguration.MaxSuggestions),
+                        DisplayLabel = "Max \"Did you mean...\" Suggestions",
+                        DisplayDescription = "Number of spelling suggestions to show when no definitions are found (1-25)",
+                        PluginOptionType = PluginAdditionalOption.AdditionalOptionType.Textbox,
+                        TextValue = ConfigurationManager.Configuration.MaxSuggestions.ToString()
+                    },
+                    new PluginAdditionalOption
+                    {
                         Key = nameof(PluginConfiguration.ShowAntonymsInResults),
                         DisplayLabel = "Show Antonyms",
                         DisplayDescription = "Display antonyms in results",
@@ -526,6 +534,11 @@ namespace Community.PowerToys.Run.Plugin.Definition
         {
             ConfigurationManager.UpdateConfiguration(config =>
             {
+                if (settings.AdditionalOptions.SingleOrDefault(x => x.Key == nameof(PluginConfiguration.MaxSuggestions)) is var maxSugOption && maxSugOption != null && int.TryParse(maxSugOption.TextValue, out var maxSug) && maxSug > 0)
+                {
+                    config.MaxSuggestions = Math.Min(maxSug, 25);
+                }
+
                 if (settings.AdditionalOptions.SingleOrDefault(x => x.Key == nameof(PluginConfiguration.CacheMaxSize)) is var cacheOption && cacheOption != null)
                 {
                     if (int.TryParse(cacheOption.TextValue, out var cacheMaxSize))

--- a/Definition/Community.PowerToys.Run.Plugin.Definition/SuggestionProvider.cs
+++ b/Definition/Community.PowerToys.Run.Plugin.Definition/SuggestionProvider.cs
@@ -22,9 +22,9 @@ namespace Community.PowerToys.Run.Plugin.Definition
             _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
         }
 
-        public async Task<List<string>> GetSuggestionsAsync(string word, CancellationToken token)
+        public async Task<List<string>> GetSuggestionsAsync(string word, int max, CancellationToken token)
         {
-            if (string.IsNullOrWhiteSpace(word) || word.Length > 50)
+            if (string.IsNullOrWhiteSpace(word) || word.Length > 50 || max <= 0)
             {
                 return new List<string>();
             }
@@ -32,7 +32,7 @@ namespace Community.PowerToys.Run.Plugin.Definition
             try
             {
                 // sp=word* — fuzzy spell check; max=5 keeps it fast
-                var url = $"{DatamuseApiBase}{Uri.EscapeDataString(word)}*&max=5";
+                var url = $"{DatamuseApiBase}{Uri.EscapeDataString(word)}*&max={Math.Min(max, 25)}";
                 using var response = await _httpClient.GetAsync(url, token);
                 if (!response.IsSuccessStatusCode)
                 {
@@ -44,7 +44,7 @@ namespace Community.PowerToys.Run.Plugin.Definition
                 return doc.RootElement.EnumerateArray()
                     .Select(e => e.TryGetProperty("word", out var w) ? w.GetString() : null)
                     .Where(w => !string.IsNullOrWhiteSpace(w) && !string.Equals(w, word, StringComparison.OrdinalIgnoreCase))
-                    .Take(5)
+                    .Take(max)
                     .ToList()!;
             }
             catch (Exception)

--- a/Definition/Community.PowerToys.Run.Plugin.Definition/SuggestionProvider.cs
+++ b/Definition/Community.PowerToys.Run.Plugin.Definition/SuggestionProvider.cs
@@ -1,0 +1,57 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net.Http;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace Community.PowerToys.Run.Plugin.Definition
+{
+    /// <summary>
+    /// "Did you mean...?" suggestions via the free Datamuse API (no key required)
+    /// when dictionary lookup returns zero results.
+    /// </summary>
+    internal class SuggestionProvider
+    {
+        private const string DatamuseApiBase = "https://api.datamuse.com/words?sp=";
+        private readonly HttpClient _httpClient;
+
+        public SuggestionProvider(HttpClient httpClient)
+        {
+            _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        }
+
+        public async Task<List<string>> GetSuggestionsAsync(string word, CancellationToken token)
+        {
+            if (string.IsNullOrWhiteSpace(word) || word.Length > 50)
+            {
+                return new List<string>();
+            }
+
+            try
+            {
+                // sp=word* — fuzzy spell check; max=5 keeps it fast
+                var url = $"{DatamuseApiBase}{Uri.EscapeDataString(word)}*&max=5";
+                using var response = await _httpClient.GetAsync(url, token);
+                if (!response.IsSuccessStatusCode)
+                {
+                    return new List<string>();
+                }
+
+                await using var stream = await response.Content.ReadAsStreamAsync(token);
+                using var doc = await JsonDocument.ParseAsync(stream, cancellationToken: token);
+                return doc.RootElement.EnumerateArray()
+                    .Select(e => e.TryGetProperty("word", out var w) ? w.GetString() : null)
+                    .Where(w => !string.IsNullOrWhiteSpace(w) && !string.Equals(w, word, StringComparison.OrdinalIgnoreCase))
+                    .Take(5)
+                    .ToList()!;
+            }
+            catch (Exception)
+            {
+                // Suggestions are best-effort; never surface errors to the user
+                return new List<string>();
+            }
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -150,6 +150,7 @@ Definition is a plugin for [Microsoft PowerToys Run](https://github.com/microsof
 
 ## ✨ Features
 
+- 💡 **"Did you mean…?" spelling suggestions** — When a word isn't found, the plugin suggests up to 25 similar spellings (Datamuse API, no key needed). Click a suggestion to search it instantly. [v1.6.0]
 - 🔍 **Instant Definitions**: Get definitions in real-time via `dictionaryapi.dev`.
 - 🇫🇷 **French Dictionary (Français)**: Lookup French words via Collins with Wiktionnaire fallback.
 - 🇮🇹 **Italian Dictionary (Italiano)**: Lookup Italian words via Wikizionario.
@@ -257,6 +258,7 @@ The plugin supports extensive customization through a `config.json` file that's 
 | `ShowExamplesInResults` | true | Show usage examples |
 | `ShowSynonymsInResults` | true | Show synonyms |
 | `ShowAntonymsInResults` | true | Show antonyms |
+| `MaxSuggestions` | 10 | Number of "Did you mean…?" spelling suggestions when no definitions are found (1–25) |
 
 ### Example Configuration
 


### PR DESCRIPTION
## What

When a dictionary lookup returns zero results, the plugin now asks Datamuse (free API, no key) for spell-checked alternatives and shows clickable **"Did you mean: word?"** results. Clicking one re-runs the query with the corrected spelling (`ChangeQuery`).

## Why

The most common dictionary-plugin failure is a typo: "definately", "recieve", "serendipityy". Until now the plugin just said "No definitions found". Now it recovers the user's intent.

## Details

- `SuggestionProvider` — Datamuse `sp=<word>*&max=5`, filters out the original word, never throws (best-effort)
- `Main.BuildNotFoundResultsAsync` — appends up to 5 suggestion results below the "no definitions" info row
- Zero new dependencies (HttpClient + System.Text.Json only)
- Reuses existing shared HttpClient with the plugin's User-Agent

## Tests

4 new unit tests: JSON parse + original-word filter, HTTP error → empty, garbage JSON → empty, >50-char input → empty.
Build: 0 warnings, 0 errors (Release, EnableWindowsTargeting).
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/ruslanlap/powertoysrun-definition/pull/17" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->